### PR TITLE
Refactors

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,5 +6,6 @@ pip install -r requirements/prod.txt
 
 python manage.py collectstatic --no-input
 python manage.py migrate
-export DJANGO_SETTINGS_MODULE=cleartask.settings.prod
-python create_user.py
+# # Use only once
+# export DJANGO_SETTINGS_MODULE=cleartask.settings.prod
+# python create_user.py

--- a/create_user.py
+++ b/create_user.py
@@ -10,4 +10,4 @@ from decouple import config
 from django.contrib.auth import get_user_model
 
 User = get_user_model()
-User.objects.create_superuser(config('SUPERUSER_NAME', cast=str), '', config('SUPERUSER_PASSWORD', cast=str), is_staff=True)
+User.objects.create_superuser(config('SUPERUSER_NAME', cast=str), '', config('SUPERUSER_PASSWORD', cast=str))


### PR DESCRIPTION
Comment out create user command from script to prevent it from being run on future deployments
Remove redundant is_staff attribute from creat super user. create_superuser command set this by default